### PR TITLE
Add section with AI promt for reablocks setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ storybook-static
 
 _pagefind/
 src/stories/*
+
+.idea/

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "posthog-js": "^1.256.2",
     "posthog-node": "^5.2.1",
     "reablocks": "^10.0.3",
-    "reablocks-docs-theme": "2.3.2",
+    "reablocks-docs-theme": "2.3.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^10.0.3
         version: 10.0.3(@emotion/is-prop-valid@0.8.8)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       reablocks-docs-theme:
-        specifier: 2.3.2
-        version: 2.3.2(@emotion/is-prop-valid@0.8.8)(@types/react@19.2.15)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nextra@4.6.1(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(prop-types@15.8.1)(react-compiler-runtime@19.1.0-rc.3(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+        specifier: 2.3.3
+        version: 2.3.3(@emotion/is-prop-valid@0.8.8)(@types/react@19.2.15)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nextra@4.6.1(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(prop-types@15.8.1)(react-compiler-runtime@19.1.0-rc.3(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -4886,8 +4886,8 @@ packages:
     resolution: {integrity: sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==}
     engines: {node: '>= 0.10.0'}
 
-  reablocks-docs-theme@2.3.2:
-    resolution: {integrity: sha512-N/1EOVc2mxG2koAssSBj1y6tWaNpQHbbM7vap+jb0CjN6/y4ZPpNut2F8xJ2GBophsUfJaKV813zU7L76915YA==}
+  reablocks-docs-theme@2.3.3:
+    resolution: {integrity: sha512-QwxDppoJjHFhebWX59kuR70pzO5ZpAinVec4tO0kcljKMJaO0yRNOIJCzO/NvPZuSmHny8kFHz7s9DRvbACHKQ==}
     peerDependencies:
       next: '>=14'
       nextra: '>=4.6.0'
@@ -11386,7 +11386,7 @@ snapshots:
       kind-of: 6.0.3
       math-random: 1.0.4
 
-  reablocks-docs-theme@2.3.2(@emotion/is-prop-valid@0.8.8)(@types/react@19.2.15)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nextra@4.6.1(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(prop-types@15.8.1)(react-compiler-runtime@19.1.0-rc.3(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
+  reablocks-docs-theme@2.3.3(@emotion/is-prop-valid@0.8.8)(@types/react@19.2.15)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nextra@4.6.1(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(prop-types@15.8.1)(react-compiler-runtime@19.1.0-rc.3(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
     dependencies:
       '@headlessui/react': 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       clsx: 2.1.1

--- a/src/app/install-prompt/[framework]/route.ts
+++ b/src/app/install-prompt/[framework]/route.ts
@@ -1,0 +1,28 @@
+import { buildInstallPrompt } from '@/components/ui/install-prompt/build-prompt';
+import { getRecipe } from '@/components/ui/install-prompt/recipes';
+
+export const runtime = 'edge';
+
+// Serves the framework-specific install prompt as raw Markdown so AI agents
+// (and the "View as Markdown" button) can fetch it by URL: /install-prompt/next
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ framework: string }> }
+) {
+  const { framework } = await params;
+  const recipe = getRecipe(framework);
+
+  if (!recipe) {
+    return new Response(`Unknown framework: ${framework}`, {
+      status: 404,
+      headers: { 'content-type': 'text/plain; charset=utf-8' }
+    });
+  }
+
+  return new Response(buildInstallPrompt(recipe), {
+    headers: {
+      'content-type': 'text/markdown; charset=utf-8',
+      'cache-control': 'public, max-age=3600'
+    }
+  });
+}

--- a/src/app/install-prompt/[framework]/route.ts
+++ b/src/app/install-prompt/[framework]/route.ts
@@ -4,9 +4,11 @@ import { getRecipe } from '@/components/ui/install-prompt/recipes';
 export const runtime = 'edge';
 
 // Serves the framework-specific install prompt as raw Markdown so AI agents
-// (and the "View as Markdown" button) can fetch it by URL: /install-prompt/next
+// (and the "View as Markdown" button) can fetch it by URL:
+//   /install-prompt/next               → default theme
+//   /install-prompt/next?theme=unify   → Unify Theme variant
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ framework: string }> }
 ) {
   const { framework } = await params;
@@ -19,7 +21,12 @@ export async function GET(
     });
   }
 
-  return new Response(buildInstallPrompt(recipe), {
+  const variant =
+    new URL(request.url).searchParams.get('theme') === 'unify'
+      ? 'unify'
+      : 'default';
+
+  return new Response(buildInstallPrompt(recipe, variant), {
     headers: {
       'content-type': 'text/markdown; charset=utf-8',
       'cache-control': 'public, max-age=3600'

--- a/src/components/ui/install-prompt/InstallPromptBuilder.tsx
+++ b/src/components/ui/install-prompt/InstallPromptBuilder.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { CSSProperties, FC, useMemo, useState } from 'react';
+import { cn } from '@/utils/cn';
+import { CopyButton, Icon, buttonClass } from '@/components/main/landing/atoms';
+import { frameworkList, type FrameworkId } from './recipes';
+import { buildInstallPrompt } from './build-prompt';
+
+type CSSVarStyle = CSSProperties & Record<`--${string}`, string | number>;
+
+/**
+ * "Install with AI" tab: pick a framework, get a self-contained, paste-ready
+ * prompt that drives an AI agent through the same setup `reablocks-cli` performs.
+ */
+export const InstallPromptBuilder: FC = () => {
+  const [selected, setSelected] = useState<FrameworkId>('next');
+  const recipe =
+    frameworkList.find(r => r.id === selected) ?? frameworkList[0];
+  const prompt = useMemo(() => buildInstallPrompt(recipe), [recipe]);
+
+  return (
+    <div className="my-6 flex flex-col gap-4">
+      <div
+        role="radiogroup"
+        aria-label="Choose your framework"
+        className="grid grid-cols-3 gap-3 max-[640px]:grid-cols-1"
+      >
+        {frameworkList.map(fw => {
+          const active = fw.id === selected;
+          return (
+            <button
+              key={fw.id}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => setSelected(fw.id)}
+              className={cn(
+                'cursor-pointer rounded-[14px] border px-4 py-3 text-left transition-colors duration-150',
+                active
+                  ? 'border-blue-500 bg-blue-500/[0.08]'
+                  : 'border-rb-hairline-2 bg-white/[0.02] hover:border-rb-hairline-strong hover:bg-white/[0.05]'
+              )}
+            >
+              <span className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    'inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border',
+                    active ? 'border-blue-400' : 'border-rb-hairline-strong'
+                  )}
+                >
+                  {active && (
+                    <span className="h-1.5 w-1.5 rounded-full bg-blue-400" />
+                  )}
+                </span>
+                <span className="text-sm font-medium text-rb-fg-1">
+                  {fw.label}
+                </span>
+              </span>
+              <span className="mt-1 ml-[22px] block font-mono text-[11px] text-rb-fg-3">
+                {fw.tagline}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        className="rb-ring overflow-hidden rounded-[18px]"
+        style={{ '--rb-ring-fill': '#0B0C18' } as CSSVarStyle}
+      >
+        <div className="flex items-center gap-3 border-b border-rb-hairline bg-white/[0.02] px-4 py-2.5">
+          <span className="font-mono text-xs text-rb-fg-2">
+            Prompt · <span className="text-white">{recipe.label}</span>
+          </span>
+          <span className="ml-auto flex items-center gap-1.5">
+            <CopyButton getText={() => prompt} label="Copy prompt" />
+            <a
+              href={`/install-prompt/${recipe.id}`}
+              target="_blank"
+              rel="noreferrer"
+              className={buttonClass('ghost', 'sm')}
+            >
+              <Icon.doc />
+              View as Markdown
+            </a>
+          </span>
+        </div>
+
+        <pre className="m-0 max-h-[460px] overflow-auto whitespace-pre-wrap bg-transparent px-5 py-4 font-mono text-[12.5px] leading-[1.6] text-rb-fg-2 max-[640px]:px-3.5 max-[640px]:py-3.5 max-[640px]:text-[12px]">
+          {prompt}
+        </pre>
+
+        <p className="border-t border-rb-hairline bg-white/[0.01] px-5 py-2.5 text-[11px] text-rb-fg-3">
+          Paste into Claude Code, Cursor, or any AI coding agent. Produces the
+          same setup as{' '}
+          <code className="font-mono text-rb-fg-2">
+            npx reablocks-cli@latest init
+          </code>{' '}
+          for {recipe.label}.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/install-prompt/InstallPromptBuilder.tsx
+++ b/src/components/ui/install-prompt/InstallPromptBuilder.tsx
@@ -4,19 +4,29 @@ import { CSSProperties, FC, useMemo, useState } from 'react';
 import { cn } from '@/utils/cn';
 import { CopyButton, Icon, buttonClass } from '@/components/main/landing/atoms';
 import { frameworkList, type FrameworkId } from './recipes';
-import { buildInstallPrompt } from './build-prompt';
+import { buildInstallPrompt, type ThemeVariant } from './build-prompt';
 
 type CSSVarStyle = CSSProperties & Record<`--${string}`, string | number>;
 
 /**
- * "Install with AI" tab: pick a framework, get a self-contained, paste-ready
- * prompt that drives an AI agent through the same setup `reablocks-cli` performs.
+ * "Install with AI" builder: pick a framework, get a self-contained,
+ * paste-ready prompt for an AI coding agent. The `variant` prop pins the
+ * theme: 'default' (Setup page — mirrors `reablocks-cli`) or 'unify'
+ * (Unify Theme page — UDS / Figma-synced production setup).
  */
-export const InstallPromptBuilder: FC = () => {
+export const InstallPromptBuilder: FC<{ variant?: ThemeVariant }> = ({
+  variant = 'default'
+}) => {
   const [selected, setSelected] = useState<FrameworkId>('next');
   const recipe =
     frameworkList.find(r => r.id === selected) ?? frameworkList[0];
-  const prompt = useMemo(() => buildInstallPrompt(recipe), [recipe]);
+  const prompt = useMemo(
+    () => buildInstallPrompt(recipe, variant),
+    [recipe, variant]
+  );
+  const markdownHref = `/install-prompt/${recipe.id}${
+    variant === 'unify' ? '?theme=unify' : ''
+  }`;
 
   return (
     <div className="my-6 flex flex-col gap-4">
@@ -71,11 +81,14 @@ export const InstallPromptBuilder: FC = () => {
         <div className="flex items-center gap-3 border-b border-rb-hairline bg-white/[0.02] px-4 py-2.5">
           <span className="font-mono text-xs text-rb-fg-2">
             Prompt · <span className="text-white">{recipe.label}</span>
+            {variant === 'unify' && (
+              <span className="text-cyan-300"> · Unify</span>
+            )}
           </span>
           <span className="ml-auto flex items-center gap-1.5">
             <CopyButton getText={() => prompt} label="Copy prompt" />
             <a
-              href={`/install-prompt/${recipe.id}`}
+              href={markdownHref}
               target="_blank"
               rel="noreferrer"
               className={buttonClass('ghost', 'sm')}
@@ -91,12 +104,21 @@ export const InstallPromptBuilder: FC = () => {
         </pre>
 
         <p className="border-t border-rb-hairline bg-white/[0.01] px-5 py-2.5 text-[11px] text-rb-fg-3">
-          Paste into Claude Code, Cursor, or any AI coding agent. Produces the
-          same setup as{' '}
-          <code className="font-mono text-rb-fg-2">
-            npx reablocks-cli@latest init
-          </code>{' '}
-          for {recipe.label}.
+          {variant === 'unify' ? (
+            <>
+              Paste into Claude Code, Cursor, or any AI coding agent. Sets up
+              the Unify Theme (UDS / Figma-synced tokens) for {recipe.label}.
+            </>
+          ) : (
+            <>
+              Paste into Claude Code, Cursor, or any AI coding agent. Produces
+              the same setup as{' '}
+              <code className="font-mono text-rb-fg-2">
+                npx reablocks-cli@latest init
+              </code>{' '}
+              for {recipe.label}.
+            </>
+          )}
         </p>
       </div>
     </div>

--- a/src/components/ui/install-prompt/build-prompt.test.ts
+++ b/src/components/ui/install-prompt/build-prompt.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { buildInstallPrompt } from './build-prompt';
+import { recipes, frameworkList } from './recipes';
+
+describe('frameworkList', () => {
+  it('exposes exactly next, vite and react-router, in order', () => {
+    expect(frameworkList.map(r => r.id)).toEqual([
+      'next',
+      'vite',
+      'react-router'
+    ]);
+  });
+});
+
+describe('buildInstallPrompt — sections shared by every framework', () => {
+  for (const recipe of frameworkList) {
+    describe(recipe.id, () => {
+      const prompt = buildInstallPrompt(recipe);
+
+      it('names the target framework', () => {
+        expect(prompt).toContain(recipe.label);
+      });
+
+      it('installs reablocks + the exact Tailwind v4 dependencies', () => {
+        expect(prompt).toContain('npm install reablocks');
+        expect(prompt).toContain('tailwindcss@4');
+        // PostCSS plugin for Next.js; Vite plugin for Vite-based frameworks.
+        if (recipe.viteBased) {
+          expect(prompt).toContain('@tailwindcss/vite');
+        } else {
+          expect(prompt).toContain('@tailwindcss/postcss');
+        }
+      });
+
+      it('wires the Tailwind v4 integration that matches the build tool', () => {
+        if (recipe.viteBased) {
+          // Vite-based: the Vite plugin in vite.config — no PostCSS config.
+          expect(prompt).toContain('@tailwindcss/vite');
+          expect(prompt).toMatch(/vite\.config/);
+          expect(prompt).toContain('tailwindcss()');
+          expect(prompt).not.toContain("'@tailwindcss/postcss': {}");
+        } else {
+          // PostCSS-based (Next.js): the PostCSS plugin config.
+          expect(prompt).toMatch(/postcss\.config/);
+          expect(prompt).toContain("'@tailwindcss/postcss': {}");
+          expect(prompt).not.toContain('@tailwindcss/vite');
+        }
+      });
+
+      it('wires Tailwind v4 + reablocks into the framework stylesheet', () => {
+        expect(prompt).toContain('@import "tailwindcss";');
+        expect(prompt).toContain(recipe.cssPath);
+        expect(prompt).toContain(recipe.sourceLine);
+      });
+
+      it('embeds the full reablocks theme token block', () => {
+        expect(prompt).toContain('--reablocks-theme');
+        expect(prompt).toContain('@custom-variant dark');
+        expect(prompt).toContain('@theme static');
+      });
+
+      it('sets the default theme class on the html host', () => {
+        expect(prompt).toContain(recipe.htmlHost);
+        expect(prompt).toContain(`${recipe.htmlAttr}="theme-dark"`);
+      });
+
+      it('wraps the app in ThemeProvider imported from reablocks', () => {
+        expect(prompt).toContain('<ThemeProvider theme={theme}>');
+        expect(prompt).toContain("from 'reablocks'");
+      });
+
+      it('includes ALWAYS / NEVER guardrails and a verification checklist', () => {
+        expect(prompt).toContain('ALWAYS');
+        expect(prompt).toContain('NEVER');
+        expect(prompt.toLowerCase()).toContain('verify');
+      });
+
+      it('never suggests Tailwind v3 or a competing UI library', () => {
+        expect(prompt).not.toContain('@tailwind base');
+        expect(prompt).not.toMatch(/content:\s*\[/); // tailwind.config content array
+        expect(prompt).not.toMatch(/shadcn|@mui\/material|@chakra-ui/i);
+      });
+    });
+  }
+});
+
+describe('buildInstallPrompt — framework specifics', () => {
+  it('Next.js uses a use-client Providers wrapper with the right @source depth', () => {
+    const prompt = buildInstallPrompt(recipes.next);
+    expect(prompt).toContain("'use client'");
+    expect(prompt).toContain('app/providers.tsx');
+    expect(prompt).toContain('export function Providers');
+    expect(prompt).toContain('../../node_modules/reablocks');
+  });
+
+  it('Vite wraps <App /> in main.tsx and uses the plain html class attribute', () => {
+    const prompt = buildInstallPrompt(recipes.vite);
+    expect(prompt).toContain('src/main.tsx');
+    expect(prompt).toContain('index.html');
+    expect(prompt).toContain('class="theme-dark"');
+    expect(prompt).toContain('<App />');
+  });
+
+  it('React Router wraps {children} in the root.tsx Layout', () => {
+    const prompt = buildInstallPrompt(recipes['react-router']);
+    expect(prompt).toContain('app/root.tsx');
+    expect(prompt).toContain('{children}');
+    expect(prompt).toContain('app/app.css');
+  });
+});
+
+describe('buildInstallPrompt — review hardening', () => {
+  it('Next.js keeps every file path under src/app so the @source depth stays correct', () => {
+    const prompt = buildInstallPrompt(recipes.next);
+    expect(prompt).toContain('src/app/globals.css');
+    expect(prompt).toContain('../../node_modules/reablocks');
+    expect(prompt).toContain('src/app/layout.tsx');
+    expect(prompt).toContain('src/app/providers.tsx');
+    // no bare `app/layout.tsx` / `app/providers.tsx` (without the src/ prefix),
+    // which would imply a one-segment @source and leave components unstyled.
+    expect(prompt).not.toMatch(/(?<!src\/)\bapp\/layout\.tsx/);
+    expect(prompt).not.toMatch(/(?<!src\/)\bapp\/providers\.tsx/);
+  });
+
+  it('ties the @source line to the stylesheet path with an explicit depth rule', () => {
+    for (const recipe of frameworkList) {
+      const prompt = buildInstallPrompt(recipe).toLowerCase();
+      expect(prompt).toContain('relative to');
+      expect(prompt).toContain('count the'); // "count the directories ..."
+    }
+  });
+
+  it('guards against a pre-existing PostCSS config instead of blindly creating one', () => {
+    expect(buildInstallPrompt(recipes.next).toLowerCase()).toContain(
+      'already exists'
+    );
+  });
+
+  it('uses the @tailwindcss/vite plugin for Vite-based frameworks only', () => {
+    expect(buildInstallPrompt(recipes.vite)).toContain('@tailwindcss/vite');
+    expect(buildInstallPrompt(recipes['react-router'])).toContain(
+      '@tailwindcss/vite'
+    );
+    // Next.js is not Vite-based — it must stay on the PostCSS plugin.
+    expect(buildInstallPrompt(recipes.next)).not.toContain('@tailwindcss/vite');
+    expect(buildInstallPrompt(recipes.next)).toContain('@tailwindcss/postcss');
+  });
+
+  it('reminds the agent that the stylesheet must be imported by the app', () => {
+    for (const recipe of frameworkList) {
+      expect(buildInstallPrompt(recipe).toLowerCase()).toContain('imported by');
+    }
+  });
+});
+
+describe('buildInstallPrompt — skills bootstrap', () => {
+  it('tells the agent to install the official reablocks AI skills, before anything else', () => {
+    for (const recipe of frameworkList) {
+      const prompt = buildInstallPrompt(recipe);
+      expect(prompt).toContain('npx skills add reaviz/skills');
+      // The skills must be installed BEFORE the package install so the agent
+      // has the canonical reablocks knowledge loaded first.
+      expect(prompt.indexOf('npx skills add reaviz/skills')).toBeLessThan(
+        prompt.indexOf('npm install reablocks')
+      );
+    }
+  });
+
+  it('mentions the skills in the ALWAYS guardrails', () => {
+    const always = buildInstallPrompt(recipes.next).split('## NEVER')[0];
+    expect(always.toLowerCase()).toContain('skills');
+  });
+});

--- a/src/components/ui/install-prompt/build-prompt.test.ts
+++ b/src/components/ui/install-prompt/build-prompt.test.ts
@@ -171,3 +171,65 @@ describe('buildInstallPrompt — skills bootstrap', () => {
     expect(always.toLowerCase()).toContain('skills');
   });
 });
+
+describe('buildInstallPrompt — Unify theme variant', () => {
+  for (const recipe of frameworkList) {
+    describe(recipe.id, () => {
+      const prompt = buildInstallPrompt(recipe, 'unify');
+
+      it('downloads themeUnify.ts and copies the CSS layers from the starter', () => {
+        expect(prompt).toContain('https://reablocks.dev/assets/themeUnify.ts');
+        expect(prompt).toContain('goodcodeus/app-starter');
+        expect(prompt).toContain('main-react-query');
+        expect(prompt).toContain('src/assets/styles'); // starter source path
+        expect(prompt).toContain('tw.css');
+        expect(prompt).toContain('index.css');
+      });
+
+      it('mentions the Figma plugin export as the UDS alternative', () => {
+        expect(prompt).toContain('Reablocks Figma Plugin');
+        expect(prompt).toContain('Export Styles');
+      });
+
+      it('wires ThemeProvider with the themeUnify module, not the default theme', () => {
+        expect(prompt).toContain('<ThemeProvider theme={theme}>');
+        expect(prompt).toMatch(/from '(\.\.?\/)+themeUnify'/);
+        // ThemeProvider still comes from the reablocks package itself
+        expect(prompt).toContain("import { ThemeProvider } from 'reablocks';");
+      });
+
+      it('never pastes the default token block or references unpublished unify exports', () => {
+        expect(prompt).not.toContain('@theme static'); // default-token-block marker
+        expect(prompt).not.toContain('--color-black-pearl'); // default palette
+        expect(prompt).not.toContain('reablocks/unify.css'); // not shipped on npm
+        expect(prompt).not.toContain('themeUnify } from'); // no package import
+      });
+
+      it('keeps the skills bootstrap and per-framework Tailwind integration', () => {
+        expect(prompt).toContain('npx skills add reaviz/skills');
+        if (recipe.viteBased) {
+          expect(prompt).toContain('@tailwindcss/vite');
+          expect(prompt).not.toContain("'@tailwindcss/postcss': {}");
+        } else {
+          expect(prompt).toContain("'@tailwindcss/postcss': {}");
+        }
+      });
+
+      it('imports the styles entry and keeps tw.css last', () => {
+        expect(prompt).toContain('./assets/styles/index.css');
+        expect(prompt.toLowerCase()).toContain('last');
+      });
+
+      it('sets the theme class on the html host', () => {
+        expect(prompt).toContain(recipe.htmlHost);
+        expect(prompt).toContain(`${recipe.htmlAttr}="theme-dark"`);
+      });
+    });
+  }
+
+  it('defaults to the default theme variant — existing prompts unchanged', () => {
+    const prompt = buildInstallPrompt(recipes.next);
+    expect(prompt).toContain('@theme static');
+    expect(prompt).not.toContain('themeUnify');
+  });
+});

--- a/src/components/ui/install-prompt/build-prompt.ts
+++ b/src/components/ui/install-prompt/build-prompt.ts
@@ -1,0 +1,165 @@
+import { FrameworkRecipe } from './recipes';
+import { REABLOCKS_THEME_TOKENS } from './reablocks-theme-tokens';
+
+// `T` is a literal backtick and `FENCE` a markdown code fence. Referencing them
+// via interpolation keeps every literal backtick out of this file's template
+// literals, so the generated markdown can be edited without escaping headaches.
+const T = '`';
+const FENCE = '```';
+
+function fenced(lang: string, body: string): string {
+  return `${FENCE}${lang}\n${body}\n${FENCE}`;
+}
+
+function header(recipe: FrameworkRecipe): string {
+  return [
+    `# Add reablocks to my ${recipe.label} project`,
+    '',
+    `You are an expert React engineer. Add **reablocks** — a React UI component library styled with **Tailwind CSS v4** and themed through its ${T}<ThemeProvider>${T} — to my existing **${recipe.label}** project.`,
+    '',
+    `Start by installing Reaviz's official AI skills (Step 1) so you have the canonical, up-to-date reablocks knowledge loaded, then follow the remaining steps exactly. Do not substitute a different UI or styling library, and do not change my app architecture beyond what these steps require.`
+  ].join('\n');
+}
+
+function guardrails(): string {
+  return [
+    '## ALWAYS do',
+    '',
+    `- Install the official reablocks AI skills first (${T}npx skills add reaviz/skills${T}) and follow them — they carry Reaviz's canonical, current reablocks + Tailwind v4 guidance.`,
+    `- Use **Tailwind CSS v4** — the ${T}@import "tailwindcss"${T} + ${T}@source${T} + ${T}@theme${T} syntax. reablocks targets v4, not v3.`,
+    '- Install only the dependencies listed below.',
+    `- Put the reablocks theme token block in the **same stylesheet** that has ${T}@import "tailwindcss"${T}.`,
+    `- Wrap the app with ${T}<ThemeProvider theme={theme}>${T} from ${T}reablocks${T}.`,
+    `- Put a ${T}theme-dark${T} (or ${T}theme-light${T}) class on the root ${T}<html>${T} element.`,
+    '- Use my existing package manager — detect it from the lockfile (npm / pnpm / yarn / bun) and translate the install commands accordingly.',
+    '',
+    '## NEVER do',
+    '',
+    `- Do NOT use Tailwind v3 syntax — no ${T}@tailwind${T} directives, no ${T}tailwind.config${T} content globs. reablocks needs v4.`,
+    '- Do NOT install or scaffold a different component library or design system.',
+    '- Do NOT omit the theme token block — without it reablocks components render unstyled.',
+    `- Do NOT place ${T}<ThemeProvider>${T} inside a Server Component (Next.js App Router); it must live in a Client Component.`
+  ].join('\n');
+}
+
+function steps(recipe: FrameworkRecipe): string {
+  const installNote =
+    '(Use the equivalent for your package manager — e.g. ' +
+    `${T}pnpm add${T} / ${T}pnpm add -D${T}, ${T}yarn add${T} / ${T}yarn add -D${T}, ${T}bun add${T} / ${T}bun add -d${T}.)`;
+
+  // Static-HTML hosts (Vite's index.html) use `class`; JSX hosts use `tsx`.
+  const htmlLang = recipe.htmlAttr === 'class' ? 'html' : 'tsx';
+
+  // Tailwind v4 integrates per build tool: Vite-based frameworks use the
+  // `@tailwindcss/vite` plugin (no PostCSS config); Next.js runs CSS through
+  // PostCSS, so it needs `@tailwindcss/postcss` in postcss.config.
+  const integrationDep = recipe.viteBased
+    ? '@tailwindcss/vite'
+    : '@tailwindcss/postcss';
+
+  const integrationStep = recipe.viteBased
+    ? [
+        '### 3. Enable the Tailwind v4 Vite plugin',
+        '',
+        `Add the ${T}@tailwindcss/vite${T} plugin to your ${T}vite.config.ts${T}, next to the framework's own plugin. Vite-based projects do **not** need a PostCSS config for Tailwind:`,
+        '',
+        fenced('ts', recipe.viteConfigSnippet ?? ''),
+        '',
+        `If a ${T}postcss.config.*${T} already adds Tailwind, remove that entry — use one integration, not both.`
+      ]
+    : [
+        '### 3. Enable the Tailwind v4 PostCSS plugin',
+        '',
+        `Next.js processes CSS through PostCSS, so add the Tailwind v4 plugin to your PostCSS config (${T}postcss.config.mjs${T} — create it if missing):`,
+        '',
+        fenced(
+          'js',
+          "// postcss.config.mjs\nexport default {\n  plugins: {\n    '@tailwindcss/postcss': {}\n  }\n};"
+        ),
+        '',
+        `If a ${T}postcss.config.{js,cjs,mjs,ts}${T} already exists, add the ${T}@tailwindcss/postcss${T} plugin to that file instead of creating a second config.`
+      ];
+
+  return [
+    '## Steps',
+    '',
+    '### 1. Install the reablocks AI skills',
+    '',
+    `Install Reaviz's official AI skills so you have the canonical, always-current reablocks API + Tailwind v4 setup knowledge loaded before you start:`,
+    '',
+    fenced('sh', 'npx skills add reaviz/skills'),
+    '',
+    `(Team alternative: symlink the ${T}reablocks${T} skill tree into ${T}.claude/skills/${T}.) Once installed, follow the skills' guidance — the steps below match it.`,
+    '',
+    '### 2. Install dependencies',
+    '',
+    fenced(
+      'sh',
+      `npm install reablocks\nnpm install -D tailwindcss@4 ${integrationDep}`
+    ),
+    '',
+    installNote,
+    '',
+    ...integrationStep,
+    '',
+    '### 4. Wire Tailwind v4 + reablocks into your stylesheet',
+    '',
+    `Open ${T}${recipe.cssPath}${T} (your main stylesheet) and add this at the very top:`,
+    '',
+    fenced('css', `@import "tailwindcss";\n${recipe.sourceLine}`),
+    '',
+    `**The ${T}@source${T} path matters.** It is resolved relative to the stylesheet's own location, so count the directories from ${T}${recipe.cssPath}${T} up to ${T}node_modules${T} and use that many ${T}../${T} segments. The line above is correct for ${T}${recipe.cssPath}${T}; recompute it only if you move the stylesheet.`,
+    '',
+    `Then paste the reablocks theme token block immediately after the ${T}@source${T} line. It defines the reablocks color palette, ${T}@custom-variant${T} rules, and ${T}@theme${T} tokens:`,
+    '',
+    fenced('css', REABLOCKS_THEME_TOKENS.trimEnd()),
+    '',
+    `### 5. Set the default theme class on ${T}<html>${T}`,
+    '',
+    `In ${T}${recipe.htmlHost}${T}, add the theme class to the root ${T}<html>${T} tag (set it once):`,
+    '',
+    fenced(htmlLang, recipe.htmlSnippet),
+    '',
+    `Swap ${T}theme-dark${T} for ${T}theme-light${T} to default to light mode.`,
+    '',
+    '### 6. Wrap your app with ThemeProvider',
+    '',
+    recipe.providerInstructions,
+    '',
+    fenced('tsx', recipe.providerSnippet)
+  ].join('\n');
+}
+
+function verification(recipe: FrameworkRecipe): string {
+  const integrationDep = recipe.viteBased
+    ? '@tailwindcss/vite'
+    : '@tailwindcss/postcss';
+  return [
+    '## Verify',
+    '',
+    'After the changes, confirm each item:',
+    '',
+    `- [ ] ${T}reablocks${T}, ${T}tailwindcss${T} (v4) and ${T}${integrationDep}${T} are in ${T}package.json${T}.`,
+    `- [ ] ${T}${recipe.cssPath}${T} starts with ${T}@import "tailwindcss";${T}, then the ${T}@source${T} line, then the ${T}--reablocks-theme${T} token block.`,
+    `- [ ] ${T}${recipe.cssPath}${T} is imported by the app entry so the styles actually load.`,
+    `- [ ] ${T}${recipe.htmlHost}${T} has ${T}${recipe.htmlAttr}="theme-dark"${T} on the ${T}<html>${T} tag.`,
+    `- [ ] The app root is wrapped in ${T}<ThemeProvider theme={theme}>${T}.`,
+    `- [ ] A ${T}<Button>${T} imported from ${T}reablocks${T} renders styled (rounded corners, blue primary fill).`,
+    '',
+    'Report each item as ✅ or ❌ when you are done.'
+  ].join('\n');
+}
+
+/**
+ * Build the self-contained, framework-specific install prompt. The output is
+ * Markdown and is used verbatim by both the copy button and the
+ * `/install-prompt/<id>` route.
+ */
+export function buildInstallPrompt(recipe: FrameworkRecipe): string {
+  return [
+    header(recipe),
+    guardrails(),
+    steps(recipe),
+    verification(recipe)
+  ].join('\n\n');
+}

--- a/src/components/ui/install-prompt/build-prompt.ts
+++ b/src/components/ui/install-prompt/build-prompt.ts
@@ -1,6 +1,13 @@
 import { FrameworkRecipe } from './recipes';
 import { REABLOCKS_THEME_TOKENS } from './reablocks-theme-tokens';
 
+/**
+ * 'default' — the standard reablocks `theme` (Tailwind token block, mirrors
+ * the CLI). 'unify' — the production Unify Theme (Figma-generated CSS token
+ * layers + downloaded `themeUnify.ts`; assets are files, not npm imports).
+ */
+export type ThemeVariant = 'default' | 'unify';
+
 // `T` is a literal backtick and `FENCE` a markdown code fence. Referencing them
 // via interpolation keeps every literal backtick out of this file's template
 // literals, so the generated markdown can be edited without escaping headaches.
@@ -11,25 +18,54 @@ function fenced(lang: string, body: string): string {
   return `${FENCE}${lang}\n${body}\n${FENCE}`;
 }
 
-function header(recipe: FrameworkRecipe): string {
+function header(recipe: FrameworkRecipe, variant: ThemeVariant): string {
+  const intro =
+    variant === 'unify'
+      ? `You are an expert React engineer. Add **reablocks** with the **Unify Theme** — the production design-token theme synced with the Unify Design System (UDS) in Figma, built on **Tailwind CSS v4** — to my existing **${recipe.label}** project.`
+      : `You are an expert React engineer. Add **reablocks** — a React UI component library styled with **Tailwind CSS v4** and themed through its ${T}<ThemeProvider>${T} — to my existing **${recipe.label}** project.`;
+
   return [
-    `# Add reablocks to my ${recipe.label} project`,
+    variant === 'unify'
+      ? `# Add reablocks (Unify Theme) to my ${recipe.label} project`
+      : `# Add reablocks to my ${recipe.label} project`,
     '',
-    `You are an expert React engineer. Add **reablocks** — a React UI component library styled with **Tailwind CSS v4** and themed through its ${T}<ThemeProvider>${T} — to my existing **${recipe.label}** project.`,
+    intro,
     '',
     `Start by installing Reaviz's official AI skills (Step 1) so you have the canonical, up-to-date reablocks knowledge loaded, then follow the remaining steps exactly. Do not substitute a different UI or styling library, and do not change my app architecture beyond what these steps require.`
   ].join('\n');
 }
 
-function guardrails(): string {
+function guardrails(variant: ThemeVariant): string {
+  const alwaysThemeBullets =
+    variant === 'unify'
+      ? [
+          `- Install the Unify assets as files (Step 4) — the CSS token layers and the ${T}themeUnify.ts${T} module live in the repo, not in the npm package.`,
+          `- Wrap the app with ${T}<ThemeProvider theme={theme}>${T} where ${T}theme${T} comes from the ${T}themeUnify${T} module (${T}ThemeProvider${T} itself comes from ${T}reablocks${T}).`
+        ]
+      : [
+          `- Put the reablocks theme token block in the **same stylesheet** that has ${T}@import "tailwindcss"${T}.`,
+          `- Wrap the app with ${T}<ThemeProvider theme={theme}>${T} from ${T}reablocks${T}.`
+        ];
+
+  const neverThemeBullets =
+    variant === 'unify'
+      ? [
+          `- Do NOT import the default ${T}theme${T} from ${T}reablocks${T} — for Unify the theme comes from the ${T}themeUnify${T} module.`,
+          '- Do NOT try to import Unify CSS or a Unify theme from the reablocks npm package — they are not shipped; the assets are installed as files in Step 4.',
+          `- Do NOT paste the default reablocks token block into the stylesheet — ${T}tw.css${T} already registers every Unify token.`,
+          `- Do NOT reorder the imports inside ${T}index.css${T} — ${T}tw.css${T} must come last.`
+        ]
+      : [
+          '- Do NOT omit the theme token block — without it reablocks components render unstyled.'
+        ];
+
   return [
     '## ALWAYS do',
     '',
     `- Install the official reablocks AI skills first (${T}npx skills add reaviz/skills${T}) and follow them — they carry Reaviz's canonical, current reablocks + Tailwind v4 guidance.`,
     `- Use **Tailwind CSS v4** — the ${T}@import "tailwindcss"${T} + ${T}@source${T} + ${T}@theme${T} syntax. reablocks targets v4, not v3.`,
     '- Install only the dependencies listed below.',
-    `- Put the reablocks theme token block in the **same stylesheet** that has ${T}@import "tailwindcss"${T}.`,
-    `- Wrap the app with ${T}<ThemeProvider theme={theme}>${T} from ${T}reablocks${T}.`,
+    ...alwaysThemeBullets,
     `- Put a ${T}theme-dark${T} (or ${T}theme-light${T}) class on the root ${T}<html>${T} element.`,
     '- Use my existing package manager — detect it from the lockfile (npm / pnpm / yarn / bun) and translate the install commands accordingly.',
     '',
@@ -37,12 +73,12 @@ function guardrails(): string {
     '',
     `- Do NOT use Tailwind v3 syntax — no ${T}@tailwind${T} directives, no ${T}tailwind.config${T} content globs. reablocks needs v4.`,
     '- Do NOT install or scaffold a different component library or design system.',
-    '- Do NOT omit the theme token block — without it reablocks components render unstyled.',
+    ...neverThemeBullets,
     `- Do NOT place ${T}<ThemeProvider>${T} inside a Server Component (Next.js App Router); it must live in a Client Component.`
   ].join('\n');
 }
 
-function steps(recipe: FrameworkRecipe): string {
+function steps(recipe: FrameworkRecipe, variant: ThemeVariant): string {
   const installNote =
     '(Use the equivalent for your package manager — e.g. ' +
     `${T}pnpm add${T} / ${T}pnpm add -D${T}, ${T}yarn add${T} / ${T}yarn add -D${T}, ${T}bun add${T} / ${T}bun add -d${T}.)`;
@@ -102,6 +138,59 @@ function steps(recipe: FrameworkRecipe): string {
     '',
     ...integrationStep,
     '',
+    ...themeSteps(recipe, variant, htmlLang)
+  ].join('\n');
+}
+
+function themeSteps(
+  recipe: FrameworkRecipe,
+  variant: ThemeVariant,
+  htmlLang: string
+): string[] {
+  const themeClassStep = [
+    `### 5. Set the default theme class on ${T}<html>${T}`,
+    '',
+    `In ${T}${recipe.htmlHost}${T}, add the theme class to the root ${T}<html>${T} tag (set it once):`,
+    '',
+    fenced(htmlLang, recipe.htmlSnippet),
+    '',
+    variant === 'unify'
+      ? `Swap ${T}theme-dark${T} for ${T}theme-light${T} to default to light mode. Unify also recognizes ${T}.dark${T} / ${T}.light${T} classes and ${T}data-theme${T} attributes.`
+      : `Swap ${T}theme-dark${T} for ${T}theme-light${T} to default to light mode.`
+  ];
+
+  if (variant === 'unify') {
+    return [
+      '### 4. Install the Unify Theme assets',
+      '',
+      `The Unify Theme is two parts — Figma-generated CSS token layers and a TypeScript component-theme module. Neither ships inside the ${T}reablocks${T} npm package; install both as files:`,
+      '',
+      `**a) Download the component-theme module** to ${T}${recipe.unify.themeUnifyPath}${T}:`,
+      '',
+      fenced(
+        'sh',
+        `curl -o ${recipe.unify.themeUnifyPath} https://reablocks.dev/assets/themeUnify.ts`
+      ),
+      '',
+      `**b) Copy the CSS token layers** — ${T}index.css${T}, ${T}common.css${T}, ${T}root.css${T}, ${T}dark.css${T}, ${T}light.css${T}, ${T}tw.css${T} — into ${T}${recipe.unify.stylesDir}/${T}. They live at ${T}src/assets/styles/${T} on the ${T}main-react-query${T} branch of the official Unify starter:`,
+      '',
+      'https://github.com/goodcodeus/app-starter/tree/main-react-query',
+      '',
+      `(If the team uses the Unify Design System in Figma, export fresh layers instead: Reablocks Figma Plugin → **Export Styles** → unzip into ${T}${recipe.unify.stylesDir}/${T}.)`,
+      '',
+      `${T}tw.css${T} already contains ${T}@import 'tailwindcss'${T}, the ${T}@source${T} directive for reablocks, and the ${T}@theme inline${T} token registration — do not add the default reablocks token block on top. Verify the ${T}@source${T} path resolves to ${T}node_modules/reablocks${T} relative to ${T}${recipe.unify.stylesDir}/tw.css${T}; if components render unstyled, adjust the ${T}../${T} depth.`,
+      '',
+      ...themeClassStep,
+      '',
+      '### 6. Wrap your app with ThemeProvider + import the styles',
+      '',
+      `Import the Unify styles entry once at the app root and wrap the app with ${T}<ThemeProvider>${T}, using the ${T}theme${T} from the ${T}themeUnify${T} module — NOT the default theme from the package. Keep the import order inside ${T}index.css${T} unchanged: ${T}tw.css${T} must stay last:`,
+      '',
+      fenced('tsx', recipe.unify.providerSnippet)
+    ];
+  }
+
+  return [
     '### 4. Wire Tailwind v4 + reablocks into your stylesheet',
     '',
     `Open ${T}${recipe.cssPath}${T} (your main stylesheet) and add this at the very top:`,
@@ -114,37 +203,45 @@ function steps(recipe: FrameworkRecipe): string {
     '',
     fenced('css', REABLOCKS_THEME_TOKENS.trimEnd()),
     '',
-    `### 5. Set the default theme class on ${T}<html>${T}`,
-    '',
-    `In ${T}${recipe.htmlHost}${T}, add the theme class to the root ${T}<html>${T} tag (set it once):`,
-    '',
-    fenced(htmlLang, recipe.htmlSnippet),
-    '',
-    `Swap ${T}theme-dark${T} for ${T}theme-light${T} to default to light mode.`,
+    ...themeClassStep,
     '',
     '### 6. Wrap your app with ThemeProvider',
     '',
     recipe.providerInstructions,
     '',
     fenced('tsx', recipe.providerSnippet)
-  ].join('\n');
+  ];
 }
 
-function verification(recipe: FrameworkRecipe): string {
+function verification(recipe: FrameworkRecipe, variant: ThemeVariant): string {
   const integrationDep = recipe.viteBased
     ? '@tailwindcss/vite'
     : '@tailwindcss/postcss';
+
+  const themeChecks =
+    variant === 'unify'
+      ? [
+          `- [ ] ${T}${recipe.unify.stylesDir}/${T} contains ${T}index.css${T}, ${T}common.css${T}, ${T}root.css${T}, ${T}dark.css${T}, ${T}light.css${T} and ${T}tw.css${T}; ${T}${recipe.unify.themeUnifyPath}${T} exists.`,
+          `- [ ] ${T}${recipe.unify.stylesDir}/index.css${T} is imported by the app entry, with ${T}tw.css${T} last in its import chain.`,
+          `- [ ] ${T}${recipe.htmlHost}${T} has ${T}${recipe.htmlAttr}="theme-dark"${T} on the ${T}<html>${T} tag.`,
+          `- [ ] The app root is wrapped in ${T}<ThemeProvider theme={theme}>${T} with ${T}theme${T} imported from the ${T}themeUnify${T} module.`,
+          `- [ ] A ${T}<Button>${T} imported from ${T}reablocks${T} renders with Unify styling (UDS tokens — e.g. ${T}bg-background-brand-base${T} resolves).`
+        ]
+      : [
+          `- [ ] ${T}${recipe.cssPath}${T} starts with ${T}@import "tailwindcss";${T}, then the ${T}@source${T} line, then the ${T}--reablocks-theme${T} token block.`,
+          `- [ ] ${T}${recipe.cssPath}${T} is imported by the app entry so the styles actually load.`,
+          `- [ ] ${T}${recipe.htmlHost}${T} has ${T}${recipe.htmlAttr}="theme-dark"${T} on the ${T}<html>${T} tag.`,
+          `- [ ] The app root is wrapped in ${T}<ThemeProvider theme={theme}>${T}.`,
+          `- [ ] A ${T}<Button>${T} imported from ${T}reablocks${T} renders styled (rounded corners, blue primary fill).`
+        ];
+
   return [
     '## Verify',
     '',
     'After the changes, confirm each item:',
     '',
     `- [ ] ${T}reablocks${T}, ${T}tailwindcss${T} (v4) and ${T}${integrationDep}${T} are in ${T}package.json${T}.`,
-    `- [ ] ${T}${recipe.cssPath}${T} starts with ${T}@import "tailwindcss";${T}, then the ${T}@source${T} line, then the ${T}--reablocks-theme${T} token block.`,
-    `- [ ] ${T}${recipe.cssPath}${T} is imported by the app entry so the styles actually load.`,
-    `- [ ] ${T}${recipe.htmlHost}${T} has ${T}${recipe.htmlAttr}="theme-dark"${T} on the ${T}<html>${T} tag.`,
-    `- [ ] The app root is wrapped in ${T}<ThemeProvider theme={theme}>${T}.`,
-    `- [ ] A ${T}<Button>${T} imported from ${T}reablocks${T} renders styled (rounded corners, blue primary fill).`,
+    ...themeChecks,
     '',
     'Report each item as ✅ or ❌ when you are done.'
   ].join('\n');
@@ -153,13 +250,16 @@ function verification(recipe: FrameworkRecipe): string {
 /**
  * Build the self-contained, framework-specific install prompt. The output is
  * Markdown and is used verbatim by both the copy button and the
- * `/install-prompt/<id>` route.
+ * `/install-prompt/<id>` route (`?theme=unify` for the Unify variant).
  */
-export function buildInstallPrompt(recipe: FrameworkRecipe): string {
+export function buildInstallPrompt(
+  recipe: FrameworkRecipe,
+  variant: ThemeVariant = 'default'
+): string {
   return [
-    header(recipe),
-    guardrails(),
-    steps(recipe),
-    verification(recipe)
+    header(recipe, variant),
+    guardrails(variant),
+    steps(recipe, variant),
+    verification(recipe, variant)
   ].join('\n\n');
 }

--- a/src/components/ui/install-prompt/index.ts
+++ b/src/components/ui/install-prompt/index.ts
@@ -1,0 +1,4 @@
+export { InstallPromptBuilder } from './InstallPromptBuilder';
+export { buildInstallPrompt } from './build-prompt';
+export { frameworkList, recipes, getRecipe } from './recipes';
+export type { FrameworkId, FrameworkRecipe } from './recipes';

--- a/src/components/ui/install-prompt/index.ts
+++ b/src/components/ui/install-prompt/index.ts
@@ -1,4 +1,5 @@
 export { InstallPromptBuilder } from './InstallPromptBuilder';
 export { buildInstallPrompt } from './build-prompt';
+export type { ThemeVariant } from './build-prompt';
 export { frameworkList, recipes, getRecipe } from './recipes';
-export type { FrameworkId, FrameworkRecipe } from './recipes';
+export type { FrameworkId, FrameworkRecipe, UnifyRecipe } from './recipes';

--- a/src/components/ui/install-prompt/reablocks-theme-tokens.ts
+++ b/src/components/ui/install-prompt/reablocks-theme-tokens.ts
@@ -1,30 +1,13 @@
-@import "tailwindcss";
-@import "./landing.css";
+// Reablocks Tailwind v4 theme tokens.
+//
+// SYNC POINT: this block is vendored verbatim from
+// reablocks-cli/src/utils/reablocks-theme-tokens.ts so the AI-install prompt
+// hands the agent exactly the CSS the CLI would write. If reablocks' theme
+// tokens change, update this file and the CLI together.
+//
+// Idempotency marker: --reablocks-theme.
 
-@source './**/*.{ts,tsx}';
-@source '../../node_modules/reablocks';
-
-
-/* Spectrum gradient border tokens (used by .rb-ring / .rb-ring-overlay) */
-:root {
-  --rb-grad-border: linear-gradient(
-    135deg,
-    rgba(0, 197, 240, 0.45) 0%,
-    rgba(16, 94, 255, 0.25) 35%,
-    rgba(167, 139, 250, 0.30) 65%,
-    rgba(0, 197, 240, 0.45) 100%
-  );
-  --rb-grad-border-hover: linear-gradient(
-    135deg,
-    rgba(0, 197, 240, 0.0) 0%,
-    rgba(0, 197, 240, 0.65) 30%,
-    rgba(16, 94, 255, 0.65) 70%,
-    rgba(0, 197, 240, 0.0) 100%
-  );
-  --rb-grad-border-glow: rgba(0, 197, 240, 0.35);
-}
-
-/* Color palette */
+export const REABLOCKS_THEME_TOKENS = `/* Color palette */
 :root,
 :host {
   --reablocks-theme: dark;
@@ -74,8 +57,8 @@
   --surface-accent: var(--color-blue-500);
 
   /* Text colors */
-  --text-primary: var(--color-white);
-  --text-secondary: var(--color-mist-gray);
+  --text-primary: var(--color-athens-gray);
+  --text-secondary: var(--color-waterloo);
 
   /* Custom Backgrounds */
   --bottom-border-glow: radial-gradient(
@@ -100,8 +83,8 @@
     rgba(23, 23, 255, 0.1) 100%
   );
 
-  .light,
-  &.light,
+  .theme-light,
+  &.theme-light,
   [data-theme='light'],
   &[data-theme='light'] {
     --reablocks-theme: light;
@@ -157,31 +140,12 @@
 }
 
 /* Custom variants */
-@custom-variant dark (&:where(.dark, .dark *, [data-theme=dark], [data-theme=dark] *));
-@custom-variant light (&:where(.light, .light *, [data-theme=light], [data-theme=light] *));
+@custom-variant dark (&:where(.theme-dark, .theme-dark *, [data-theme=dark], [data-theme=dark] *));
+@custom-variant light (&:where(.theme-light, .theme-light *, [data-theme=light], [data-theme=light] *));
 @custom-variant disabled-within (&:has(input:is(:disabled), textarea:is(:disabled), button:is(:disabled)));
 
-/* Define theme tokens */
+/* Semantic color tokens - use inline because they reference var() */
 @theme inline {
-  --breakpoint-2xl: 1440px;
-
-  /* Fonts */
-  --font-sans: Inter, sans-serif;
-  --font-mono: Fira Code, monospace;
-
-  --shadow-code: 0px_4px_16px_0px_rgba(0,0,0,0.25);
-
-  /* Font sizes */
-  --text-xs: 0.625rem; /* 10px */
-  --text-xs--line-height: 1rem;
-  --text-sm: 0.75rem; /* 12px */
-  --text-sm--line-height: 1rem;
-  --text-base: 0.875rem; /* 14px */
-  --text-base--line-height: 1.25rem;
-  --text-lg: 1rem; /* 16px */
-  --text-lg--line-height: 1.5rem;
-  --text-7.5xl: 5.625rem;
-
   /* Primary colors */
   --color-primary: var(--primary);
   --color-primary-active: var(--primary-active);
@@ -229,6 +193,47 @@
   /* Text colors */
   --color-text-primary: var(--text-primary);
   --color-text-secondary: var(--text-secondary);
+}
+
+/* Static theme tokens - emits CSS custom properties for runtime access */
+@theme static {
+  /* Fonts */
+  --font-sans: Inter, sans-serif;
+  --font-mono: Fira Code, monospace;
+
+  /* Font sizes */
+  --text-xs: 0.625rem; /* 10px */
+  --text-xs--line-height: 1rem;
+  --text-sm: 0.75rem; /* 12px */
+  --text-sm--line-height: 1rem;
+  --text-base: 0.875rem; /* 14px */
+  --text-base--line-height: 1.25rem;
+  --text-lg: 1rem; /* 16px */
+  --text-lg--line-height: 1.5rem;
+
+  /* Spacing */
+  --spacing: 0.25rem;
+
+  /* Border radius */
+  --radius-xs: 0.125rem;
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+  --radius-2xl: 1rem;
+  --radius-3xl: 1.5rem;
+  --radius-4xl: 2rem;
+
+  /* Shadows */
+  --shadow-2xs: 0 1px rgb(0 0 0 / 0.05);
+  --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-xl:
+    0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
 
   /* Base colors */
   --color-white: #ffffff;
@@ -406,288 +411,10 @@
   /* Named colors */
   --color-black-pearl: #02020f;
   --color-athens-gray: #f7f7fa;
-  --color-athens-dark-navy-overlay: #0909194D;
-  --color-mist-gray: #ADAFBD;
   --color-mystic: #e6e6f0;
   --color-vulcan: #11111f;
   --color-charade: #242433;
   --color-waterloo: #77778c;
   --color-anakiwa: #93b6ff;
-
-  /* Reablocks landing tokens */
-  --color-rb-bg-0: #0B0B14;
-  --color-rb-bg-1: #11111F;
-  --color-rb-bg-2: #121212;
-  --color-rb-surface-1: #161623;
-  --color-rb-surface-2: #1C1C2C;
-  --color-rb-surface-3: #232337;
-  --color-rb-fg-1: #F5F6FB;
-  --color-rb-fg-2: #B6BACB;
-  --color-rb-fg-3: #7E839A;
-  --color-rb-fg-muted: #565B73;
-  --color-rb-hairline: rgba(255,255,255,0.07);
-  --color-rb-hairline-2: rgba(255,255,255,0.12);
-  --color-rb-hairline-strong: rgba(122,165,255,0.32);
-  --color-rb-good: #4ADE80;
-  --color-rb-warn: #F59E0B;
-  --color-rb-bad: #F87171;
-  --color-rb-cat-elements: #3B7BFF;
-  --color-rb-cat-form: #00C5F0;
-  --color-rb-cat-layers: #A78BFA;
-  --color-rb-cat-layout: #34D399;
-  --color-rb-cat-data: #FBBF24;
-  --color-rb-cat-motion: #FB7185;
-
-  /* Reablocks display font */
-  --font-display: Lexend, Inter, sans-serif;
-
-  /* Reablocks landing animations */
-  --animate-rb-drift: rb-drift 30s ease-in-out infinite;
-  --animate-rb-float: rb-float 9s ease-in-out infinite alternate;
-  --animate-rb-peek-a: rb-peek-a 12s ease-in-out infinite alternate;
-  --animate-rb-peek-b: rb-peek-b 14s ease-in-out infinite alternate;
-  --animate-rb-caret: rb-caret 1.1s steps(1, end) infinite;
-  --animate-rb-notif-in: rb-notif-in 280ms cubic-bezier(.2,.7,.2,1);
-  --animate-rb-rise: rb-rise 700ms ease-out forwards;
-  --animate-rb-ping: rb-ping 2s cubic-bezier(0, 0, 0.2, 1) infinite;
 }
-
-@keyframes rb-drift {
-  0%, 100% { transform: translate(0, 0); }
-  25%      { transform: translate(12px, -8px); }
-  50%      { transform: translate(0, 0); }
-  75%      { transform: translate(-12px, 8px); }
-}
-@keyframes rb-float {
-  from { translate: 0 -2px; }
-  to   { translate: 0  3px; }
-}
-@keyframes rb-peek-a {
-  from { transform: rotate(4deg)  translateY(-4px); }
-  to   { transform: rotate(4deg)  translateY( 8px); }
-}
-@keyframes rb-peek-b {
-  from { transform: rotate(-3deg) translateY( 6px); }
-  to   { transform: rotate(-3deg) translateY(-6px); }
-}
-@keyframes rb-caret { 50% { opacity: 0; } }
-@keyframes rb-notif-in {
-  from { opacity: 0; transform: translateY(8px) scale(0.98); }
-  to   { opacity: 1; transform: none; }
-}
-@keyframes rb-rise { to { opacity: 1; transform: none; } }
-@keyframes rb-ping {
-  75%, 100% { transform: scale(2.2); opacity: 0; }
-}
-
-body {
-  line-height: inherit;
-}
-
-/* Backdrop background for layouts component */
-.backdrop-bg::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  background-size: contain;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-image: var(--backdrop-url);
-}
-
-
-html.light {
-  --background: #ffffff;
-  --tooltip-background: #f7f7fa;
-  --tooltip-color: #3d3d4d;
-  --foreground: #000000;
-  --foreground-rgb: 0, 0, 0;
-}
-
-html.dark {
-  --background: #11101f;
-  --tooltip-background: #00050be6;
-  --tooltip-color: #fff;
-  --foreground: #ffffff;
-  --foreground-rgb: 255, 255, 255;
-}
-
-body {
-  color: rgb(var(--foreground-rgb)) !important;
-  background-color: var(--background) !important;
-  --tooltip-spacing: 5px;
-  --tooltip-border-radius: 5px;
-}
-
-.nextra-sidebar {
-  font-family: var(--font-sans), 'sans-serif';
-}
-
-.nextra-nav-container > nav {
-  background-color: var(--background) !important;
-}
-
-.nextra-nav-container {
-  border-bottom: solid 1px hsla(203, 50%, 30%, 0.15) !important;
-}
-
-.nextra-nav-container-blur {
-  display: none;
-}
-
-.docblock-code-toggle {
-  background: black !important;
-  color: white !important;
-  border: none !important;
-  border-radius: 0 !important;
-}
-
-.docblock-code-toggle ~ button {
-  background: black !important;
-  color: white !important;
-  border: none !important;
-  border-radius: 0 !important;
-}
-
-.nextra-toc > div > div {
-  background: none !important;
-  box-shadow: none !important;
-  border-top: solid 1px hsla(203, 50%, 30%, 0.15) !important;
-}
-
-.nextra-sidebar-container > .nx-sticky {
-  background: transparent !important;
-  box-shadow: none !important;
-}
-
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
-
-  /* Visually hidden until focused — skip-to-content link */
-  .rb-skip-link {
-    position: fixed;
-    top: 0.5rem;
-    left: 0.5rem;
-    z-index: 100;
-    padding: 0.5rem 0.875rem;
-    border-radius: 8px;
-    background: var(--color-blue-500);
-    color: #ffffff;
-    font-family: var(--font-sans);
-    font-size: 13px;
-    font-weight: 500;
-    text-decoration: none;
-    box-shadow: 0 8px 24px -10px rgba(16, 94, 255, 0.7);
-    transform: translateY(-150%);
-    transition: transform 150ms ease-out;
-  }
-
-  .rb-skip-link:focus,
-  .rb-skip-link:focus-visible {
-    transform: translateY(0);
-    outline: 2px solid #ffffff;
-    outline-offset: 2px;
-  }
-}
-
-.sbdocs {
-  background: transparent !important;
-  padding: 0 !important;
-  gap: 0 !important;
-}
-
-.nextra-content p,
-.nextra-content li,
-.nextra-toc p {
-  color: rgb(var(--foreground-rgb)) !important;
-}
-
-.sbdocs-content {
-  max-width: 100% !important;
-}
-
-.sbdocs-content > div > .nx-flex {
-  margin-left: auto !important;
-  margin-right: auto !important;
-}
-
-.nextra-toc ul,
-.nextra-menu-desktop,
-.nextra-menu-desktop ul {
-  padding-left: auto !important;
-  list-style: none !important;
-}
-
-.nextra-cards > a {
-  @apply hover:bg-gray-100 dark:hover:bg-gray-700/20;
-}
-
-.nextra-code, .rb-code {
-  color: #029cfd !important;
-}
-
-.rb-code-block {
-  margin-top: 1px;
-  background: transparent;
-}
-
-.rb-code-block code {
-  display: block !important;
-}
-
-.sbdocs-preview {
-  border-color: hsl(
-    var(--nextra-primary-hue) var(--nextra-primary-saturation) 94%/0.1
-  ) !important;
-}
-
-pre.highlighter code {
-  display: block;
-}
-
-pre {
-  background-color: hsl(var(--nextra-primary-hue)var(--nextra-primary-saturation)77%/.1);
-  box-shadow: none;
-  border-radius: 0;
-}
-
-.prismjs > div {
-  /** Handle storybook code samples running off the page */
-  white-space: pre-wrap !important;
-}
-
-input {
-  --tw-ring-opacity: 0 !important;
-  --tw-ring-offset-shadow: none !important;
-}
-
-svg {
-  overflow: visible;
-}
-
-/* TSDocProps: tag required props with a trailing "*".
-   Nextra adds `after:content-["?"]` to optional name <code>s; the absence of
-   that class means the prop is required. */
-.tsdoc-props tbody td:first-child code:not([class*="after:content"])::after {
-  content: "*";
-  margin-left: 0.15em;
-  color: #ef4444;
-  font-weight: 700;
-  font-size: 0.85em;
-  vertical-align: super;
-  line-height: 0;
-  user-select: none;
-}
-
-/* StoryRenderer (reablocks-docs-theme): contain wide story content within the
-   bordered preview container instead of overflowing the page. The inner
-   wrapper uses width: fit-content, so when its content is wider than the
-   container we get a horizontal scroll inside the container. */
-.story-container.story-preview > div {
-  max-width: 100%;
-  overflow-x: auto;
-}
-
+`;

--- a/src/components/ui/install-prompt/recipes.ts
+++ b/src/components/ui/install-prompt/recipes.ts
@@ -1,0 +1,160 @@
+// Per-framework install recipes. Declarative data consumed by
+// `buildInstallPrompt` — each field mirrors exactly what reablocks-cli does for
+// that framework, so an AI agent following the generated prompt produces the
+// same result as running `npx reablocks-cli@latest init`.
+
+export type FrameworkId = 'next' | 'vite' | 'react-router';
+
+export interface FrameworkRecipe {
+  /** Stable id, used in the markdown route (`/install-prompt/<id>`). */
+  id: FrameworkId;
+  /** Human-facing label shown on the card and in the prompt. */
+  label: string;
+  /** Short tagline shown under the label on the card. */
+  tagline: string;
+  /** Main stylesheet the CLI wires Tailwind v4 + reablocks into. */
+  cssPath: string;
+  /**
+   * Tailwind v4 `@source` line, with the exact `../` depth for `cssPath`.
+   * Tailwind resolves `@source` relative to the stylesheet's own location.
+   */
+  sourceLine: string;
+  /** File that owns the root `<html>` element. */
+  htmlHost: string;
+  /** JSX (`className`) vs static HTML (`class`) attribute for the host. */
+  htmlAttr: 'className' | 'class';
+  /** The `<html>` opening tag the user should end up with. */
+  htmlSnippet: string;
+  /** Prose describing where/how to wrap the app with ThemeProvider. */
+  providerInstructions: string;
+  /** The ThemeProvider wiring code block for this framework. */
+  providerSnippet: string;
+  /** True for Vite-powered frameworks (Vite, React Router v7 / Remix). These
+   * use the native `@tailwindcss/vite` plugin and need no PostCSS config. */
+  viteBased?: boolean;
+  /** For Vite-based frameworks: the `vite.config.ts` showing the Tailwind v4
+   * plugin added alongside the framework's own plugin. */
+  viteConfigSnippet?: string;
+}
+
+const NEXT: FrameworkRecipe = {
+  id: 'next',
+  label: 'Next.js (App Router)',
+  tagline: 'app/ router',
+  cssPath: 'src/app/globals.css',
+  sourceLine: '@source "../../node_modules/reablocks";',
+  htmlHost: 'src/app/layout.tsx',
+  htmlAttr: 'className',
+  htmlSnippet: '<html lang="en" className="theme-dark">',
+  providerInstructions:
+    "Server Components can't host React context, so create a client `Providers` component and use it from your existing `src/app/layout.tsx`. (If you already have a providers file, wrap its contents with `<ThemeProvider>` instead of creating a new one.)",
+  providerSnippet: `// src/app/providers.tsx  — new client component
+'use client';
+
+import { ThemeProvider, theme } from 'reablocks';
+import type { ReactNode } from 'react';
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}
+
+// src/app/layout.tsx  — edit your existing layout:
+//   1. import the Providers component
+//   2. add the theme class to <html>
+//   3. wrap {children} with <Providers>
+import { Providers } from './providers';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="theme-dark">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}`
+};
+
+const VITE: FrameworkRecipe = {
+  id: 'vite',
+  label: 'Vite',
+  tagline: 'React + Vite',
+  cssPath: 'src/index.css',
+  sourceLine: '@source "../node_modules/reablocks";',
+  htmlHost: 'index.html',
+  htmlAttr: 'class',
+  htmlSnippet: '<html lang="en" class="theme-dark">',
+  providerInstructions:
+    'Wrap `<App />` with `<ThemeProvider theme={theme}>` in `src/main.tsx`:',
+  providerSnippet: `// src/main.tsx
+import { ThemeProvider, theme } from 'reablocks';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
+  </StrictMode>,
+);`,
+  viteBased: true,
+  viteConfigSnippet: `// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()]
+});`
+};
+
+const REACT_ROUTER: FrameworkRecipe = {
+  id: 'react-router',
+  label: 'React Router (RR7 / Remix)',
+  tagline: 'framework mode',
+  cssPath: 'app/app.css',
+  sourceLine: '@source "../node_modules/reablocks";',
+  htmlHost: 'app/root.tsx',
+  htmlAttr: 'className',
+  htmlSnippet: '<html lang="en" className="theme-dark">',
+  providerInstructions:
+    'In `app/root.tsx`, wrap `{children}` inside the existing `Layout` component with `<ThemeProvider theme={theme}>`:',
+  providerSnippet: `// app/root.tsx
+import { ThemeProvider, theme } from 'reablocks';
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className="theme-dark">
+      <head>
+        {/* ...existing head... */}
+      </head>
+      <body>
+        <ThemeProvider theme={theme}>{children}</ThemeProvider>
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}`,
+  viteBased: true,
+  viteConfigSnippet: `// vite.config.ts
+import { defineConfig } from 'vite';
+import { reactRouter } from '@react-router/dev/vite'; // Remix: '@remix-run/dev'
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [reactRouter(), tailwindcss()]
+});`
+};
+
+export const recipes: Record<FrameworkId, FrameworkRecipe> = {
+  next: NEXT,
+  vite: VITE,
+  'react-router': REACT_ROUTER
+};
+
+/** Display order in the picker. */
+export const frameworkList: FrameworkRecipe[] = [NEXT, VITE, REACT_ROUTER];
+
+export function getRecipe(id: string): FrameworkRecipe | undefined {
+  return (recipes as Record<string, FrameworkRecipe>)[id];
+}

--- a/src/components/ui/install-prompt/recipes.ts
+++ b/src/components/ui/install-prompt/recipes.ts
@@ -5,6 +5,18 @@
 
 export type FrameworkId = 'next' | 'vite' | 'react-router';
 
+/** Per-framework specifics for the Unify Theme variant. The Unify assets are
+ * files in the user's repo (Figma-generated CSS layers + a downloaded
+ * `themeUnify.ts`) — they are NOT shipped inside the reablocks npm package. */
+export interface UnifyRecipe {
+  /** Directory the CSS token layers are copied into. */
+  stylesDir: string;
+  /** Where to save the downloaded themeUnify.ts module. */
+  themeUnifyPath: string;
+  /** ThemeProvider wiring incl. the styles-entry import for this framework. */
+  providerSnippet: string;
+}
+
 export interface FrameworkRecipe {
   /** Stable id, used in the markdown route (`/install-prompt/<id>`). */
   id: FrameworkId;
@@ -35,6 +47,8 @@ export interface FrameworkRecipe {
   /** For Vite-based frameworks: the `vite.config.ts` showing the Tailwind v4
    * plugin added alongside the framework's own plugin. */
   viteConfigSnippet?: string;
+  /** Unify Theme variant specifics. */
+  unify: UnifyRecipe;
 }
 
 const NEXT: FrameworkRecipe = {
@@ -72,7 +86,38 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       </body>
     </html>
   );
+}`,
+  unify: {
+    stylesDir: 'src/assets/styles',
+    themeUnifyPath: 'src/themeUnify.ts',
+    providerSnippet: `// src/app/providers.tsx  — new client component
+'use client';
+
+import { ThemeProvider } from 'reablocks';
+import { theme } from '../themeUnify';
+import type { ReactNode } from 'react';
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}
+
+// src/app/layout.tsx  — edit your existing layout:
+//   1. import the Providers component and the Unify styles entry
+//   2. add the theme class to <html>
+//   3. wrap {children} with <Providers>
+import { Providers } from './providers';
+import '../assets/styles/index.css';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="theme-dark">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
 }`
+  }
 };
 
 const VITE: FrameworkRecipe = {
@@ -104,7 +149,23 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()]
-});`
+});`,
+  unify: {
+    stylesDir: 'src/assets/styles',
+    themeUnifyPath: 'src/themeUnify.ts',
+    providerSnippet: `// src/main.tsx
+import { ThemeProvider } from 'reablocks';
+import { theme } from './themeUnify';
+import './assets/styles/index.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
+  </StrictMode>,
+);`
+  }
 };
 
 const REACT_ROUTER: FrameworkRecipe = {
@@ -143,7 +204,30 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   plugins: [reactRouter(), tailwindcss()]
-});`
+});`,
+  unify: {
+    stylesDir: 'app/assets/styles',
+    themeUnifyPath: 'app/themeUnify.ts',
+    providerSnippet: `// app/root.tsx
+import { ThemeProvider } from 'reablocks';
+import { theme } from './themeUnify';
+import './assets/styles/index.css';
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className="theme-dark">
+      <head>
+        {/* ...existing head... */}
+      </head>
+      <body>
+        <ThemeProvider theme={theme}>{children}</ThemeProvider>
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}`
+  }
 };
 
 export const recipes: Record<FrameworkId, FrameworkRecipe> = {

--- a/src/content/docs/getting-started/setup.mdx
+++ b/src/content/docs/getting-started/setup.mdx
@@ -25,7 +25,7 @@ Prefer to let an AI coding agent do the setup? Pick your framework and copy the 
 
 <InstallPromptBuilder />
 
-The prompt is framework-specific and includes guardrails (always use Tailwind v4, never swap in another UI library) plus a verification checklist. You can also fetch it directly as Markdown at `/install-prompt/<framework>`.
+The prompt is framework-specific and includes guardrails (always use Tailwind v4, never swap in another UI library) plus a verification checklist. You can also fetch it directly as Markdown at `/install-prompt/<framework>`. On the [Unify Design System](/docs/theme/theme-unify)? That page has its own AI install prompt for the Unify Theme.
 </Tabs.Tab>
 <Tabs.Tab>
 <Callout type="info" emoji="ℹ️">

--- a/src/content/docs/getting-started/setup.mdx
+++ b/src/content/docs/getting-started/setup.mdx
@@ -1,5 +1,6 @@
 import { Steps, Tabs, Callout } from 'nextra/components'
 import { InstallTerminal } from '../../../components/ui/install-terminal'
+import { InstallPromptBuilder } from '../../../components/ui/install-prompt'
 
 # Setup
 This section will guide you through the initial steps required to integrate Tailwind CSS into your project. Tailwind CSS is a utility-first CSS framework that can be customized to fit the design needs of your project. Follow these instructions to ensure a smooth setup.
@@ -7,7 +8,7 @@ This section will guide you through the initial steps required to integrate Tail
 
 ## Install
 
-<Tabs items={['CLI', 'Manual']}>
+<Tabs items={['CLI', 'AI Prompt', 'Manual']}>
 <Tabs.Tab>
 The fastest way to set up reablocks in an existing React project is the official CLI. From the root of your project:
 
@@ -18,6 +19,13 @@ npx reablocks-cli@latest init
 <InstallTerminal />
 
 Every edit is previewed and gated behind a `Y/n` confirm — nothing is written without your approval. Each step is also idempotent, so re-running on a partially configured project only touches what's missing.
+</Tabs.Tab>
+<Tabs.Tab>
+Prefer to let an AI coding agent do the setup? Pick your framework and copy the prompt — it's a self-contained brief that first installs the official [reablocks AI skills](/docs/getting-started/skills) (`npx skills add reaviz/skills`) so your agent has canonical, up-to-date knowledge, then walks Claude Code, Cursor, or any agent through the same steps the CLI performs (dependencies, Tailwind v4 wiring, theme tokens, and the `ThemeProvider`).
+
+<InstallPromptBuilder />
+
+The prompt is framework-specific and includes guardrails (always use Tailwind v4, never swap in another UI library) plus a verification checklist. You can also fetch it directly as Markdown at `/install-prompt/<framework>`.
 </Tabs.Tab>
 <Tabs.Tab>
 <Callout type="info" emoji="ℹ️">

--- a/src/content/docs/getting-started/setup.mdx
+++ b/src/content/docs/getting-started/setup.mdx
@@ -515,9 +515,6 @@ You can learn more about the Storybook setup [here](/docs/getting-started/storyb
 </Tabs.Tab>
 </Tabs>
 
-## Example Repository
-You can use the following [repository](https://github.com/goodcodeus/starter) to get started with Reablocks.
-
 ## Developing Locally
 
 If you want to run the project locally, its really easy!

--- a/src/content/docs/theme/theme-unify.mdx
+++ b/src/content/docs/theme/theme-unify.mdx
@@ -518,6 +518,10 @@ import './assets/styles/index.css'; // pulls in all CSS layers
 For the rest — provider mechanics, runtime theme switching, server-side rendering — see
 [Getting Started](/docs/theme/getting-started).
 
+## Example Repository
+
+You can use the [Unify](https://github.com/goodcodeus/app-starter/tree/main-react-query) starter repository to get started with Reablocks and the Unify Theme — it ships with the CSS token layers, the `themeUnify.ts` component-theme module, and the `ThemeProvider` wiring already in place.
+
 ## Unify-specific customization
 
 For generic single-component overrides via `extendTheme`, see
@@ -631,6 +635,7 @@ put bespoke tokens in `overrides.css`, import it last:
 
 ## Reference
 
+- Unify starter repository: [goodcodeus/app-starter](https://github.com/goodcodeus/app-starter/tree/main-react-query)
 - Unify Design System (Figma source of truth): [unifydesignsystem.com](https://unifydesignsystem.com/)
 - UDS → CSS export: [Reablocks Figma Plugin](https://www.figma.com/community/plugin/1285928654186754176/reablocks-figma-plugin)
 - General theming (ThemeProvider, dark/light, basic customization):

--- a/src/content/docs/theme/theme-unify.mdx
+++ b/src/content/docs/theme/theme-unify.mdx
@@ -1,3 +1,5 @@
+import { InstallPromptBuilder } from '../../../components/ui/install-prompt'
+
 # Unify Theme
 
 The **Unify Theme** is a complete, production-ready **reablocks theme** that consumes
@@ -175,6 +177,17 @@ so it expects them to be present in your stylesheet.
 > Prefer per-component files for easier diffing and overrides? `themeUnify.ts` also
 > exports each component theme individually (`buttonTheme`, `inputTheme`, …), so you
 > can split it back into the [File layout](#file-layout) below by hand or use it as-is.
+
+## Install with AI
+
+Prefer to let an AI coding agent set this up? Pick your framework and copy the prompt —
+a self-contained brief that first installs the official
+[reablocks AI skills](/docs/getting-started/skills) (`npx skills add reaviz/skills`),
+then walks Claude Code, Cursor, or any agent through the full Unify setup on this page:
+Tailwind v4 wiring, the `themeUnify.ts` module, the UDS CSS token layers, and the
+`ThemeProvider`. Also available as raw Markdown at `/install-prompt/<framework>?theme=unify`.
+
+<InstallPromptBuilder variant="unify" />
 
 ## Prerequisites
 


### PR DESCRIPTION
Adds an **"Install with AI"** experience to the docs: a framework picker that generates a self-contained, paste-ready Markdown prompt walking any AI coding agent (Claude Code, Cursor, etc.) through the full reablocks setup — mirroring what `npx reablocks-cli@latest init` does. Supports both the **default theme** and the **Unify Theme** variant.

## Changes

### New: Install Prompt Builder (`src/components/ui/install-prompt/`)
- **`InstallPromptBuilder.tsx`** — client component with a framework picker (Next.js, Vite, React Router/Remix), live prompt preview, copy button, and "View as Markdown" link. Accepts a `variant` prop (`default` | `unify`).
- **`build-prompt.ts`** — assembles the Markdown prompt: intro, ALWAYS/NEVER guardrails, numbered steps (skills bootstrap → deps → Tailwind v4 wiring → theme → `ThemeProvider`), and a verification checklist.
- **`recipes.ts`** — declarative per-framework data (stylesheet paths, `@source` depths, provider snippets, Unify asset locations) that mirrors `reablocks-cli` exactly.
- **`reablocks-theme-tokens.ts`** — theme token block vendored verbatim from `reablocks-cli` (documented sync point).
- **`build-prompt.test.ts`** — 60 tests covering shared sections, framework specifics, `@source` depth hardening, skills-bootstrap ordering, and the Unify variant.

### Docs
- **`setup.mdx`** — new **AI Prompt** tab alongside CLI/Manual; removed the old example-repository section.
- **`theme-unify.mdx`** — new **Install with AI** section using the `unify` variant; added the Unify starter repository (`goodcodeus/app-starter`, `main-react-query` branch) as the example repo and reference link.
